### PR TITLE
Prefer adjusting cursors over recreating them

### DIFF
--- a/src/draw-selection.ts
+++ b/src/draw-selection.ts
@@ -69,6 +69,13 @@ class Piece {
     return elt
   }
 
+  adjust(elt: HTMLElement) {
+    elt.style.left = this.left + "px"
+    elt.style.top = this.top + "px"
+    if (this.width >= 0) elt.style.width = this.width + "px"
+    elt.style.height = this.height + "px"
+  }
+
   eq(p: Piece) {
     return this.left == p.left && this.top == p.top && this.width == p.width && this.height == p.height &&
       this.className == p.className
@@ -128,8 +135,15 @@ const drawSelectionPlugin = ViewPlugin.fromClass(class {
       this.rangePieces = rangePieces
     }
     if (cursors.length != this.cursors.length || cursors.some((c, i) => !c.eq(this.cursors[i]))) {
-      this.cursorLayer.textContent = ""
-      for (let c of cursors) this.cursorLayer.appendChild(c.draw())
+      let oldCursors = Array.from(this.cursorLayer.children)
+      cursors.forEach((c, idx) => {
+        if (oldCursors[idx]) c.adjust(oldCursors[idx] as HTMLElement)
+        else this.cursorLayer.appendChild(c.draw())
+      })
+      while (oldCursors.length > cursors.length) {
+        let old = oldCursors.pop()
+        if (old) this.cursorLayer.removeChild(old)
+      }
       this.cursors = cursors
     }
   }

--- a/src/draw-selection.ts
+++ b/src/draw-selection.ts
@@ -136,13 +136,15 @@ const drawSelectionPlugin = ViewPlugin.fromClass(class {
     }
     if (cursors.length != this.cursors.length || cursors.some((c, i) => !c.eq(this.cursors[i]))) {
       let oldCursors = Array.from(this.cursorLayer.children)
-      cursors.forEach((c, idx) => {
-        if (oldCursors[idx]) c.adjust(oldCursors[idx] as HTMLElement)
-        else this.cursorLayer.appendChild(c.draw())
-      })
-      while (oldCursors.length > cursors.length) {
-        let old = oldCursors.pop()
-        if (old) this.cursorLayer.removeChild(old)
+      if (oldCursors.length !== cursors.length) {
+        this.cursorLayer.textContent = ""
+        for (const c of cursors)
+          this.cursorLayer.appendChild(c.draw())
+      } else {
+        cursors.forEach((c, idx) => {
+          if (oldCursors[idx]) c.adjust(oldCursors[idx] as HTMLElement)
+          else this.cursorLayer.appendChild(c.draw())
+        })
       }
       this.cursors = cursors
     }

--- a/src/draw-selection.ts
+++ b/src/draw-selection.ts
@@ -135,16 +135,13 @@ const drawSelectionPlugin = ViewPlugin.fromClass(class {
       this.rangePieces = rangePieces
     }
     if (cursors.length != this.cursors.length || cursors.some((c, i) => !c.eq(this.cursors[i]))) {
-      let oldCursors = Array.from(this.cursorLayer.children)
+      let oldCursors = this.cursorLayer.children
       if (oldCursors.length !== cursors.length) {
         this.cursorLayer.textContent = ""
         for (const c of cursors)
           this.cursorLayer.appendChild(c.draw())
       } else {
-        cursors.forEach((c, idx) => {
-          if (oldCursors[idx]) c.adjust(oldCursors[idx] as HTMLElement)
-          else this.cursorLayer.appendChild(c.draw())
-        })
+        cursors.forEach((c, idx) => c.adjust(oldCursors[idx] as HTMLElement))
       }
       this.cursors = cursors
     }


### PR DESCRIPTION
This makes it so that the `drawSelection` plugin will 'adjust' old cursors in the `cursorLayer` rather than simply recreating them.

Why? Well, to be honest, it's purely for gratuitous visual flair.
```ts
let theme = { '$cursor': { transition: 'left 0.1s ease-out, top 0.1s ease-out' } }
```
![image](https://i.imgur.com/q0fNfMz.gif)
(it's hard to see in a gif, but the movement is buttery smooth.)

There is a _potential_ argument about this being more efficient, as most of the time only a single cursor will need to be updated, and when it is updated only its style properties are changed. I doubt that this gives a practical improvement in performance regardless.

I have "tested" this, but I'm pretty unfamiliar with the innards of CodeMirror and the maintainer(s) probably needs to check if this change affects something that I wouldn't know about.
