### PR TITLE
Fix bug in Safari when calculating text coords of hidden nodes

### DIFF
--- a/src/inlineview.ts
+++ b/src/inlineview.ts
@@ -144,7 +144,8 @@ function textCoords(text: Node, pos: number, side: number): Rect {
   range.setEnd(text, to)
   range.setStart(text, from)
   let rects = range.getClientRects(), rect = rects[(flatten ? flatten < 0 : side >= 0) ? 0 : rects.length - 1]
-  if (browser.safari && !flatten && rect.width == 0) rect = Array.prototype.find.call(rects, r => r.width) || rect
+  // Safari can return an empty `rects` list in certain cases if the Node is hidden, so we check for existence of `rect` before accessing `.width`
+  if (browser.safari && !flatten && rect?.width == 0) rect = Array.prototype.find.call(rects, r => r.width) || rect
   return flatten ? flattenRect(rect!, flatten < 0) : rect!
 }
 


### PR DESCRIPTION
Hi @marijnh, while working on a component which uses CodeMirror I noticed some errors being raised in Safari v14.0.3.

It doesn't seem to be a fatal issue, but logs a `TypeError: undefined is not an object (evaluating 'h.width')`.

Looking into it a bit more, it seems that the issue is related to how I render the `parent` DOM element housing the editor.
Depending on the user supplied prop, the CodeMirror instance can start hidden, and later toggled to be seen.

The component [can be seen here](https://stencila.github.io/designa/iframe.html?id=objects-executabledocument--article-controls-active&viewMode=story)

![Screenshot 2021-02-03 at 18 38 40](https://user-images.githubusercontent.com/1646307/106823566-2f7b6e80-664f-11eb-8ba3-83ce9e016ed9.png)

---

What happens is that `range.getClientRects()` (linked below) returns an empty array (see screenshot from safari stopped at the breakpoint. Apologies for the minified source code). Trying to access this array with an index then returns `undefined`.

https://github.com/codemirror/view/blob/1b92b55c62697087aed79101801ef4c41a6c3d28/src/inlineview.ts#L146-L148

<img width="1125" alt="Screenshot 2021-02-03 at 17 34 44@2x" src="https://user-images.githubusercontent.com/1646307/106823931-c5af9480-664f-11eb-8c04-0f5cfcca50fa.png">

A simple fix in this case was to check the existence of the `rect` variable before accessing the `width` property. However I couldn't quite decide what should happen regarding the fallback on line 148.
There's a bit of type coercion going on, and in this case the function might return `undefined` I think. Should I stub a `Rect` object with zero dimensions in this case?


Please let me know if you have any suggested changes, if this PR is out of scope, or if a rambled too much and failed to explain the issue.
Thanks for your time!
