### PR TITLE
Fix Safari resetting input method in wrapping

### DIFF
--- a/src/viewstate.ts
+++ b/src/viewstate.ts
@@ -228,7 +228,6 @@ export class ViewState {
     this.heightMap = this.heightMap.updateHeight(
       oracle, 0, refresh, new MeasuredHeights(this.viewport.from, lineHeights))
 
-    if (oracle.heightChanged) result |= UpdateFlag.Height
     if (!this.viewportIsAppropriate(this.viewport, bias) ||
         this.scrollTo && (this.scrollTo.head < this.viewport.from || this.scrollTo.head > this.viewport.to)) {
       let newVP = this.getViewport(bias, this.scrollTo)


### PR DESCRIPTION
Context: https://discuss.codemirror.net/t/ime-is-not-working-properly-when-line-wrapping-in-safari/3250

In Safari, this line could cause input method being reset with wrapping into a new line.

Not sure about the side effects for this change. Please review. Thanks!