### PR TITLE
Update IME link

### DIFF
--- a/src/editorview.ts
+++ b/src/editorview.ts
@@ -89,7 +89,7 @@ export class EditorView {
   get inView() { return this.viewState.inView }
 
   /// Indicates whether the user is currently composing text via
-  /// [IME](https://developer.mozilla.org/en-US/docs/Mozilla/IME_handling_guide).
+  /// [IME](https://firefox-source-docs.mozilla.org/editor/IMEHandlingGuide.html).
   get composing() { return this.inputState.composing > 0 }
   
   private _dispatch: (tr: Transaction) => void


### PR DESCRIPTION
The IME handling guide has moved to https://firefox-source-docs.mozilla.org/editor/IMEHandlingGuide.html.

Archive.org link for comparison: https://web.archive.org/web/20210305082609/https://developer.mozilla.org/en-US/docs/Mozilla/IME_handling_guide