### PR TITLE
Add null check in a while loop

### DIFF
--- a/src/contentview.ts
+++ b/src/contentview.ts
@@ -227,7 +227,7 @@ function rm(dom: Node): Node {
 
 function syncNodeInto(parent: HTMLElement, after: Node | null, dom: Node) {
   let next: Node | null = after ? after.nextSibling : parent.firstChild
-  if (dom.parentNode == parent) while (next != dom) next = rm(next!)
+  if (dom.parentNode == parent) while (next && next != dom) next = rm(next!)
   else parent.insertBefore(dom, next)
 }
 


### PR DESCRIPTION
If `next` is null then `rm()` will throw an unhandled error when it tries to get the `nextSibiling` of the dom. This may resolve https://discuss.codemirror.net/t/defaulthighlightstyle-and-markdown-cause-ime-error-when-atomic-widget-presents/3385