### PR TITLE
Use ownerdocument body as top in scrollRectIntoView

### DIFF
--- a/src/dom.ts
+++ b/src/dom.ts
@@ -103,7 +103,7 @@ export function scrollRectIntoView(dom: HTMLElement, rect: Rect) {
 
   for (let cur: any = dom.parentNode; cur;) {
     if (cur.nodeType == 1) { // Element
-      let bounding: Rect, top = cur == document.body
+      let bounding: Rect, top = cur == doc.body
       if (top) {
         bounding = windowRect(win)
       } else {


### PR DESCRIPTION
when rendering codemirror inside the preview panel in Netlify CMS (which uses `react-frame-component` to render the preview into an `iframe`), the editor kept jumping up when clicking inside the editor or moving the cursor via keyboard.

this change seems to fix it for me -- note: i am totally unfamiliar with the codemirror codebase, so if this does not make sense, feel free to close the pr.

thanks!