### PR TITLE
Deal with the case of IntersectionObserver entries list being empty.

### DIFF
--- a/src/domobserver.ts
+++ b/src/domobserver.ts
@@ -81,7 +81,7 @@ export class DOMObserver {
     if (typeof IntersectionObserver == "function") {
       this.intersection = new IntersectionObserver(entries => {
         if (this.parentCheck < 0) this.parentCheck = setTimeout(this.listenForScroll.bind(this), 1000)
-        if (entries[entries.length - 1].intersectionRatio > 0 != this.intersecting) {
+        if (entries.length > 0 && entries[entries.length - 1].intersectionRatio > 0 != this.intersecting) {
           this.intersecting = !this.intersecting
           if (this.intersecting != this.view.inView)
             this.onScrollChanged(document.createEvent("Event"))
@@ -89,7 +89,7 @@ export class DOMObserver {
       }, {})
       this.intersection.observe(this.dom)
       this.gapIntersection = new IntersectionObserver(entries => {
-        if (entries[entries.length - 1].intersectionRatio > 0)
+        if (entries.length > 0 && entries[entries.length - 1].intersectionRatio > 0)
           this.onScrollChanged(document.createEvent("Event"));
       }, {})
     }


### PR DESCRIPTION
I ran into a corner case when mocking the interactions with the `IntersectionObserver` in Jest.

I'm using `mockAllIsIntersecting()` from [react-intersection-observer](https://github.com/thebuilder/react-intersection-observer) and this causes the `IntersectionObserver` callbacks in `domobserver.ts` to be called with an empty list of `entries`, which then causes a crash in the code with this error:

```
TypeError: Cannot read property 'intersectionRatio' of undefined
```

To deal with this corner case I added a guard in front of the condition against empty lists of entries.