### PR TITLE
Set `translate="no"` on editor element

### DIFF
--- a/src/editorview.ts
+++ b/src/editorview.ts
@@ -378,6 +378,7 @@ export class EditorView {
       spellcheck: "false",
       autocorrect: "off",
       autocapitalize: "off",
+      translate: "no",
       contenteditable: !this.state.facet(editable) ? "false" : contentEditablePlainTextSupported() ? "plaintext-only" : "true",
       class: "cm-content",
       style: `${browser.tabSize}: ${this.state.tabSize}`,


### PR DESCRIPTION
Using Google Translate on a page with a codemirror currently causes lots of glitches:

https://user-images.githubusercontent.com/6933510/137720409-39332f63-47d8-4fd2-8f26-98d33d21a206.mov

I added the [`translate` attribute](https://www.w3.org/International/questions/qa-translate-flag) to tell automatic translators to not translate the codemirror, I think this makes sense for code.