### PR TITLE
Increase delay for input refocus after backspace on Android

### DIFF
--- a/src/input.ts
+++ b/src/input.ts
@@ -698,7 +698,7 @@ handlers.beforeinput = (view, event) => {
   if (browser.chrome && browser.android && (pending = PendingKeys.find(key => key.inputType == event.inputType))) {
     view.inputState.setPendingKey(view, pending)
 
-    if (pending.key !== "Backspace") {
+    if (pending.key === "Enter") {
       return
     }
 

--- a/src/input.ts
+++ b/src/input.ts
@@ -697,6 +697,11 @@ handlers.beforeinput = (view, event) => {
   let pending
   if (browser.chrome && browser.android && (pending = PendingKeys.find(key => key.inputType == event.inputType))) {
     view.inputState.setPendingKey(view, pending)
+
+    if (pending.key !== "Backspace") {
+      return
+    }
+
     let startViewHeight = window.visualViewport?.height || 0
     setTimeout(() => {
       // Backspacing near uneditable nodes on Chrome Android sometimes
@@ -706,6 +711,6 @@ handlers.beforeinput = (view, event) => {
         view.contentDOM.blur()
         view.focus()
       }
-    }, 50)
+    }, 100)
   }
 }


### PR DESCRIPTION
Hey Marijn!

Following up on my bug report on some backspacing issues on Android [here](https://discuss.codemirror.net/t/cant-backspace-on-empty-line-with-widget-on-android-in-cm6/3557), these two commits seem to have helped:
- https://github.com/codemirror/view/commit/d75f3c206f2556197b6fe75e023e1fe82cde4d3b
- https://github.com/codemirror/view/commit/63193de514049a6ca7dbd626830abc8437923398

however, when I was testing this locally on my Google Pixel running Android 10, the timeout for refocusing after backspace input wasn't quite long enough which led to the virtual keyboarding not reopening when it should have. I suspect for older, less powerful devices, the virtual keyboard takes longer to close which leads to the heuristic in the set timeout flaking.

Using the following minimal repro:
- Repo: https://github.com/sergeichestakov/cm-mobile-bug-repro
- Repl: https://replit.com/@SergeiChestakov/cm-mobile-bug-repro

and linking a local version of `@codemirror/view` via `yarn link`, I was able to work around the issue by increasing the timeout from 50 to 100ms.

Additionally, I noticed that we can forego the blur/set timeout logic for the enter key which we're also processing in the `beforeinput` handler.

Think this should help address the above issue, although ideally we triage the root cause that causes the virtual keyboard to close in the first place.