### PR TITLE
Don't prevent default input behavior of enter/backspace on iOS

### DIFF
--- a/src/input.ts
+++ b/src/input.ts
@@ -13,10 +13,6 @@ export class InputState {
   lastKeyCode: number = 0
   lastKeyTime: number = 0
 
-  // On iOS, some keys need to have their default behavior happen
-  // (after which we retroactively handle them and reset the DOM) to
-  // avoid messing up the virtual keyboard state.
-  //
   // On Chrome Android, backspace near widgets is just completely
   // broken, and there are no key events, so we need to handle the
   // beforeinput event. Deleting stuff will often create a flurry of
@@ -133,17 +129,6 @@ export class InputState {
     this.lastKeyCode = event.keyCode
     this.lastKeyTime = Date.now()
     if (this.screenKeyEvent(view, event as KeyboardEvent)) return true
-    // Prevent the default behavior of Enter on iOS makes the
-    // virtual keyboard get stuck in the wrong (lowercase)
-    // state. So we let it go through, and then, in
-    // applyDOMChange, notify key handlers of it and reset to
-    // the state they produce.
-    let pending
-    if (browser.ios && (pending = PendingKeys.find(key => key.keyCode == event.keyCode)) &&
-        !(event.ctrlKey || event.altKey || event.metaKey) && !(event as any).synthetic) {
-      this.setPendingKey(view, pending)
-      return true
-    }
     return false
   }
 


### PR DESCRIPTION
Hey Marijn!

We upgraded from `@codemirror/view` 0.19.8 to 0.19.10 yesterday but had to revert it today due to a bug some iOS users were reporting where hitting the enter and backspace keys would result in them being processed twice (e.g. two new lines being inserted and two characters being deleted respectively).

Digging through the commit log between these two releases, I was able to trace it back to this commit: https://github.com/codemirror/view/commit/63193de514049a6ca7dbd626830abc8437923398.

I was also able to reproduce this locally both in our web app as well as the minimal repro I have posted in the PR description here: https://github.com/codemirror/view/pull/14#issue-1044134724.

When I `yarn link`ed my fork of `view` locally, I was able to fix the problem by removing the following lines of code in the keydown handler where we prevent the default behavior of enter/delete and set a pending key operation to be processed in the next animation frame.

I see your comment here that that logic was here to prevent the keyboard state from getting messed up, however, I was never able to reproduce that bug on my iPhone 11 Pro on iOS 15.1 (and 14.8) both in this release and previous releases so it seems safe to remove.

Let me know if I'm on the right track here or there's some other way to prevent these keys from being handled twice as it's preventing us from upgrading to the latest version of `@codemirror/view`. Thanks!