### PR TITLE
Compute posAtCoords with a loose right side clipping.

### DIFF
--- a/src/cursor.ts
+++ b/src/cursor.ts
@@ -140,7 +140,7 @@ export function posAtCoords(view: EditorView, {x, y}: {x: number, y: number}, pr
   y = docTop + yOffset
   let lineStart = block.from
   // Clip x to the viewport sides
-  x = Math.max(content.left + 1, Math.min(content.right - 1, x))
+  x = Math.max(content.left + 1, Math.min(Math.max(content.right, content.left + view.docView.minWidth) - 1, x))
   // If this is outside of the rendered viewport, we can't determine a position
   if (lineStart < view.viewport.from)
     return view.viewport.from == 0 ? 0 : posAtCoordsImprecise(view, content, block, x, y)


### PR DESCRIPTION
So we have this weird use case that's quite uncommon (and understandably not well supported by cm6).

We are using mixed line wrapping depending on the line. The reason is that we are rendering Markdown content, but line wrapping makes markdown tables very difficult to work with.

To achieve this, we forcibly override the `.cm-content`'s property `min-width: unset !important` and instead give it a max-width. Unfortunately, the side effect of doing that causes the content element to be shorter than some of its children elements, which in turn, causes `posAtCoords` calculations to be clamped to the non-overflown part of the content element.

The actual behavior observed, is that mouse selection past the wrapping point will always be clipped to within the wrapping point, which means characters outside are not selectable by mouse.

The proposed patch extends the clipping area for this specific case. This patch doesn't add any significant computation as it uses pre-computed values, and in my understanding, this clipping shouldn't even happen for the vast majority of the time because most coordinate tests are from within the content area.

(Perhaps I should add an inline comment to explain the reasoning?)

Video of current behavior:
https://user-images.githubusercontent.com/609710/144391820-438684f0-1dd2-4fbb-8031-feb7d9a9595c.mov