### PR TITLE
Clear `selectionchange` listener on editor destruction

### DIFF
--- a/src/domobserver.ts
+++ b/src/domobserver.ts
@@ -298,6 +298,7 @@ export class DOMObserver {
     this.resize?.disconnect()
     for (let dom of this.scrollTargets) dom.removeEventListener("scroll", this.onScroll)
     window.removeEventListener("scroll", this.onScroll)
+    this.dom.ownerDocument.removeEventListener("selectionchange", this.onSelectionChange)
     clearTimeout(this.parentCheck)
     clearTimeout(this.resizeTimeout)
   }


### PR DESCRIPTION
Fixes a memory leak where `onSelectionChange` was never removed from the document, which caused the editor's state to stay in memory