### PR TITLE
Fix position tests at the end of the document.

### DIFF
--- a/src/cursor.ts
+++ b/src/cursor.ts
@@ -131,7 +131,7 @@ export function posAtCoords(view: EditorView, {x, y}: {x: number, y: number}, pr
     if (block.top > yOffset || block.bottom < yOffset) {
       bias = block.top > yOffset ? -1 : 1
       yOffset = Math.min(block.bottom - halfLine, Math.max(block.top + halfLine, yOffset))
-      if (bounced) return precise ? null : 0
+      if (bounced) return precise ? null : block.top > yOffset ? 0 : view.state.doc.length
       else bounced = true
     }
     if (block.type == BlockType.Text) break


### PR DESCRIPTION
This fixes an issue where clicking at the end of the document results in the cursor to be put at the beginning, when a full line replacement block widget is used on the last few lines of the document.