### PR TITLE
Properly marking split text block as dirty.

### DIFF
--- a/src/inlineview.ts
+++ b/src/inlineview.ts
@@ -46,6 +46,7 @@ export class TextView extends ContentView {
   split(from: number) {
     let result = new TextView(this.text.slice(from))
     this.text = this.text.slice(0, from)
+    this.markDirty()
     return result
   }
 


### PR DESCRIPTION
FIX: Prevent an possibility where some content updates causes duplicate text to remain in DOM.

Closes https://github.com/codemirror/codemirror.next/issues/631