### PR TITLE
Fix 649 - Use EditorView for placeholder instead of ViewPlugin

### DIFF
--- a/src/placeholder.ts
+++ b/src/placeholder.ts
@@ -24,15 +24,5 @@ class Placeholder extends WidgetType {
 /// Extension that enables a placeholder—a piece of example content
 /// to show when the editor is empty.
 export function placeholder(content: string | HTMLElement): Extension {
-  return ViewPlugin.fromClass(class {
-    placeholder: DecorationSet
-
-    constructor(readonly view: EditorView) {
-      this.placeholder = Decoration.set([Decoration.widget({widget: new Placeholder(content), side: 1}).range(0)])
-    }
-
-    update!: () => void // Kludge to convince TypeScript that this is a plugin value
-
-    get decorations() { return this.view.state.doc.length ? Decoration.none : this.placeholder }
-  }, {decorations: v => v.decorations})
+  return EditorView.decorations.of(Decoration.set([Decoration.widget({ widget: new Placeholder(content), side: 1 }).range(0)]))
 }


### PR DESCRIPTION
Seems like with the latest release, ViewPlugins don't play so well as decorations, especially if they are borderline to cross a line.

I've taken inspiration from [this](https://github.com/codemirror/view/compare/0.19.35...0.19.36#diff-9b21fae1e6179d5485785f3b0ae7efef7c3d99bb957bdb7c3aa94c22531155e7R24) and updated the placeholder plugin helper function. It seems to work, even though you might have something else in mind.

There may be more ViewPlugins that stopped working (so this may have be a breaking change? 🤔)

https://github.com/codemirror/codemirror.next/issues/649
https://github.com/fonsp/Pluto.jl/issues/1779