### PR TITLE
Improve iOS IME handling

### DIFF
--- a/src/domobserver.ts
+++ b/src/domobserver.ts
@@ -65,9 +65,17 @@ export class DOMObserver {
       // reinsert the finished text. CodeMirror's handling of the
       // deletion will prevent the reinsertion from happening,
       // breaking composition.
-      if ((browser.ie && browser.ie_version <= 11 || browser.ios && view.compositionStarted) &&
-          mutations.some(m => m.type == "childList" && m.removedNodes.length ||
-                         m.type == "characterData"))
+      //
+      // Unrelatedly, Chrome on Windows has a bug where touching the
+      // selection while composing with IME sometimes causes the
+      // browser to misinterpret selection positions, causing the
+      // selection we set to be applied to the wrong offset (1 node before)
+      // while the browser engine still "thinks" it was applied correctly.
+      if ((
+            browser.ie && browser.ie_version <= 11 ||
+            browser.ios && view.compositionStarted ||
+            browser.windows && browser.chrome && view.compositionStarted
+          ) && mutations.some(m => m.type == "childList" && m.removedNodes.length || m.type == "characterData"))
         this.flushSoon()
       else
         this.flush()

--- a/src/domobserver.ts
+++ b/src/domobserver.ts
@@ -65,9 +65,9 @@ export class DOMObserver {
       // reinsert the finished text. CodeMirror's handling of the
       // deletion will prevent the reinsertion from happening,
       // breaking composition.
-      if ((browser.ie && browser.ie_version <= 11 || browser.ios && view.composing) &&
+      if ((browser.ie && browser.ie_version <= 11 || browser.ios && view.compositionStarted) &&
           mutations.some(m => m.type == "childList" && m.removedNodes.length ||
-                         m.type == "characterData" && m.oldValue!.length > m.target.nodeValue!.length))
+                         m.type == "characterData"))
         this.flushSoon()
       else
         this.flush()


### PR DESCRIPTION
FIX: Avoids text duplication in some cases caused by weird behaviors of IME composition on iOS.

This might not be the best code to fix this issue, please let me know if there's a better way to achieve this.

This patch fixes a specific case of iOS IME composition - it doesn't seem to happen everywhere but I have one case that triggers this (notice the space in the outer span).

```html
<span class="outer"><span class="inner">-</span> </span>
```

When the cursor is placed at the end, typing causes exponential character duplication. I've logged the events and it seems that the following happens:

- `compositionstart`
- [MutationObserver event](https://github.com/codemirror/view/blob/b286dee2d43fd1a018c77df6a1bc8bad5bd79b9b/src/domobserver.ts#L69), during which
     - `view.composing` is false but `view.inputState.compositionFirstChange` is true.
     - `m.oldValue` is `" "` and `m.target.nodeValue` is `" g"` (assuming `g` is typed).
- In this case, if `flush` is called, then iOS will immediately trigger another mutation and insert the entire composition string again (in this case, "g").
- Each new character typed repeats this process, each time inserting a full copy of the composed string, causing exponential insertion.

This patch causes `flushSoon` to be used when that happens, which causes iOS to properly keep detecting the correct composed string in the DOM and avoids inserting a new copy.

https://user-images.githubusercontent.com/609710/152015884-1af091c9-9327-403b-b171-ad1c9b65762e.mov


