### PR TITLE
Fix edge case sync crash

### DIFF
--- a/src/blockview.ts
+++ b/src/blockview.ts
@@ -216,6 +216,9 @@ export class BlockWidgetView extends ContentView implements BlockView {
 
   destroy() {
     super.destroy()
-    if (this.dom) this.widget.destroy(this.dom)
+    if (this.dom) {
+      this.dom.remove()
+      this.widget.destroy(this.dom)
+    }
   }
 }

--- a/src/inlineview.ts
+++ b/src/inlineview.ts
@@ -230,7 +230,10 @@ export class WidgetView extends ContentView {
 
   destroy() {
     super.destroy()
-    if (this.dom) this.widget.destroy(this.dom)
+    if (this.dom) {
+      this.dom.remove()
+      this.widget.destroy(this.dom)
+    }
   }
 }
 


### PR DESCRIPTION
When the document's first line is a full-line block widget, and somehow an edit is performed such that the block widget is no longer full-line, the widget is reused in `child.sync()`, causing `parent.firstChild` to be detached from `parent` and moved under the LineView of the child.

When that happens, the `pos` variable now points to an element that is not attached to the parent, which causes an exception to happen when `insertBefore` is called.

```
DOMException: Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.
```

This patch fixes this special case.