### PR TITLE
declare font attributes early

### DIFF
--- a/src/theme.ts
+++ b/src/theme.ts
@@ -37,7 +37,10 @@ export const baseTheme = buildTheme("." + baseThemeID, {
       outline: "1px dotted #212121"
     },
     display: "flex !important",
-    flexDirection: "column"
+    flexDirection: "column",
+    fontFamily: "monospace",
+    fontWeight: "normal",
+    fontStyle: "normal"
   },
 
   ".cm-scroller": {

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -46,7 +46,6 @@ export const baseTheme = buildTheme("." + baseThemeID, {
   ".cm-scroller": {
     display: "flex !important",
     alignItems: "flex-start !important",
-    fontFamily: "monospace",
     lineHeight: 1.4,
     height: "100%",
     overflowX: "auto",


### PR DESCRIPTION
https://github.com/codemirror/codemirror.next/issues/775
declare font style normal, font monospace and font width on cm-editor. Fixes print style and removes font style inheritance from parent