### PR TITLE
Add aria label to editor view for accessibility purposes

### DIFF
--- a/src/editorview.ts
+++ b/src/editorview.ts
@@ -410,6 +410,7 @@ export class EditorView {
       class: "cm-content",
       style: `${browser.tabSize}: ${this.state.tabSize}`,
       role: "textbox",
+      "aria-label": "editor",
       "aria-multiline": "true"
     }
     if (this.state.readOnly) contentAttrs["aria-readonly"] = "true"


### PR DESCRIPTION
This is the second of two PRs I have opened for accessibility (the first was [here](https://github.com/codemirror/autocomplete/pull/11)). 

I'm interested in adding an aria-label field for the editor textbox to meet the guidelines of this [accessibility check. ](https://dequeuniversity.com/rules/axe/4.3/aria-input-field-name?application=axeAPI)

I went with the value "editor" to try to stay succinct and convey that the textbox is for the code editor that the user interacts with on their screen. What do you think? 