### PR TITLE
Use opacity instead of visibility for cursor blink animation

### DIFF
--- a/src/theme.ts
+++ b/src/theme.ts
@@ -118,8 +118,8 @@ export const baseTheme = buildTheme("." + baseThemeID, {
   // Two animations defined so that we can switch between them to
   // restart the animation without forcing another style
   // recomputation.
-  "@keyframes cm-blink": {"0%": {}, "50%": {visibility: "hidden"}, "100%": {}},
-  "@keyframes cm-blink2": {"0%": {}, "50%": {visibility: "hidden"}, "100%": {}},
+  "@keyframes cm-blink": {"0%": {}, "50%": {opacity: 0}, "100%": {}},
+  "@keyframes cm-blink2": {"0%": {}, "50%": {opacity: 0}, "100%": {}},
 
   ".cm-cursor, .cm-dropCursor": {
     position: "absolute",


### PR DESCRIPTION
Clicking inside the editor on https://codemirror.net/ causes the cursor blink animation to start, which uses ~2% CPU and ~60/120 style recalculations per second (according to the Performance Monitor tab in Chrome's Dev Tools, in macOS).

Changing the animation from `visibility: hidden` to `opacity: 0` reduces both of these measurements to approximately zero.

Caveat: I'm not sure whether this has any important effects on accessibility.