### PR TITLE
Fix insert-period-on-double-space macos behaviour

### DIFF
--- a/src/domchange.ts
+++ b/src/domchange.ts
@@ -71,7 +71,7 @@ export function applyDOMChange(view: EditorView, start: number, end: number, typ
   // Detect insert-period-on-double-space Mac behavior, and transform
   // it into a regular space insert.
   else if ((browser.mac || browser.android) && change && change.from == change.to && change.from == sel.head - 1 &&
-           change.insert.toString() == ".")
+           change.insert.toString() == ". ")
     change = {from: sel.from, to: sel.to, insert: Text.of([" "])}
 
   if (change) {


### PR DESCRIPTION
If the "Add full stop with double-space" feature is enabled on macOS, typing a double space quickly inserts a period followed by a space - `. ` and not a single period character.

Fix tested on macOS Mojave 10.14