### PR TITLE
Upgrade to w3c-keyname@2.2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@codemirror/state": "^6.0.0",
     "style-mod": "^4.0.0",
-    "w3c-keyname": "^2.2.4"
+    "w3c-keyname": "^2.2.6"
   },
   "devDependencies": {
     "@codemirror/buildhelper": "^0.1.6"


### PR DESCRIPTION
Upgrades `w3c-keyname` to v2.2.6, to get [this fix](https://github.com/marijnh/w3c-keyname/commit/600aae45ece2d2e6486279c34e631695621403e2).