### PR TITLE
Add destroy method to TooltipView

### DIFF
--- a/src/tooltip.ts
+++ b/src/tooltip.ts
@@ -56,7 +56,10 @@ class TooltipViewManager {
         if (tooltipView.update) tooltipView.update(update)
       }
     }
-    for (let t of this.tooltipViews) if (tooltipViews.indexOf(t) < 0) t.dom.remove()
+    for (let t of this.tooltipViews) if (tooltipViews.indexOf(t) < 0) {
+      t.dom.remove()
+      t.destroy?.()
+    }
 
     this.input = input
     this.tooltips = tooltips
@@ -209,7 +212,10 @@ const tooltipPlugin = ViewPlugin.fromClass(class {
 
   destroy() {
     this.view.win.removeEventListener("resize", this.measureSoon)
-    for (let {dom} of this.manager.tooltipViews) dom.remove()
+    for (let tooltipView of this.manager.tooltipViews) {
+      tooltipView.dom.remove()
+      tooltipView.destroy?.()
+    }
     this.intersectionObserver?.disconnect()
     clearTimeout(this.measureTimeout)
   }
@@ -404,6 +410,9 @@ export interface TooltipView {
   mount?(view: EditorView): void
   /// Update the DOM element for a change in the view's state.
   update?(update: ViewUpdate): void
+  /// Called when the tooltip is removed from the editor or the editor
+  /// is destroyed.
+  destroy?(): void
   /// Called when the tooltip has been (re)positioned.
   positioned?(): void,
 }

--- a/test/webtest-hover.ts
+++ b/test/webtest-hover.ts
@@ -16,10 +16,10 @@ async function waitForSuccess(assert: () => void) {
   assert()
 }
 
-function setupHover(...tooltips: Array<string|{text: string, start: number, end: number}>) {
+function setupHover(...tooltips: Array<string|{text: string, start: number, end: number, destroy?: () => void}>) {
   const testText = "test"
   const hoverTooltips = tooltips.map(x => {
-    const {text, start, end} = typeof x === "string"
+    const {text, start, end, destroy} = typeof x === "string"
       ? {text: x, start: 0, end: testText.length - 1}
       : x
 
@@ -29,7 +29,7 @@ function setupHover(...tooltips: Array<string|{text: string, start: number, end:
       return {pos, create: () => {
         const dom = document.createElement("div")
         dom.innerText = text
-        return {dom}
+        return {dom, destroy}
       }}
     }, {hoverTime: 10})
   })
@@ -83,8 +83,9 @@ describe("hoverTooltip", () => {
   })
 
   it("removes tooltip view if mouse moves outside of the range", async () => {
+    let destroyed = false
     let view = setupHover(
-      {text: "remove", start: 0, end: 2},
+      {text: "remove", start: 0, end: 2, destroy: () => destroyed = true},
       {text: "keep", start: 0, end: 4}
     )
     mouseMove(view, 0)
@@ -92,6 +93,7 @@ describe("hoverTooltip", () => {
       '<div class="cm-tooltip-section">keep</div>')
     mouseMove(view, 3)
     await expectTooltip(view, '<div class="cm-tooltip-section">keep</div>')
+    ist(destroyed, true)
     view.destroy()
   })
 })


### PR DESCRIPTION
Other components that extend the editor's DOM have a `destroy` method that allows them to clean up any resources they created (e.g. `PluginValue`, `Panel`). I've been missing such a method for the `TooltipView` as well. Although I found a workaround by using `MutationObserver` like so

```
    public mount(): void {
        if (this.dom.parentElement) {
            const observer = new MutationObserver(mutations => {
                for (const mutation of mutations) {
                    if (mutation.type === 'childList' && Array.from(mutation.removedNodes).includes(this.dom)) {
                        // clean up here
                        observer.disconnect()
                        return
                    }
                }
            })
            observer.observe(this.dom.parentElement, { childList: true })
        }
    }

```

I think it would be nice to have such a method for simplicity and consistency.

Note: I extended one of the hover tests but I wasn't able to actually run web tests via `npm run test`. I got an error that the `@codemirror/view` dependency doesn't exist (which makes sense) but I don't know what the necessary steps are to get the tests running.