### PR TITLE
Take account of visibility of WidgetBufferView

### DIFF
--- a/src/inlineview.ts
+++ b/src/inlineview.ts
@@ -348,7 +348,7 @@ export class WidgetBufferView extends ContentView {
   domBoundsAround() { return null }
 
   coordsAt(pos: number): Rect | null {
-    let imgVisible = this.dom!.checkVisibility()
+    let imgVisible = this.dom!.offsetParent != null
     let imgRect = this.dom!.getBoundingClientRect()
     // Since the <img> height doesn't correspond to text height, try
     // to borrow the height from some sibling node.

--- a/src/inlineview.ts
+++ b/src/inlineview.ts
@@ -348,11 +348,13 @@ export class WidgetBufferView extends ContentView {
   domBoundsAround() { return null }
 
   coordsAt(pos: number): Rect | null {
+    let imgVisible = this.dom!.checkVisibility()
     let imgRect = this.dom!.getBoundingClientRect()
     // Since the <img> height doesn't correspond to text height, try
     // to borrow the height from some sibling node.
     let siblingRect = inlineSiblingRect(this, this.side > 0 ? -1 : 1)
-    return siblingRect && siblingRect.top < imgRect.bottom && siblingRect.bottom > imgRect.top
+    return siblingRect && !imgVisible
+      ? siblingRect : siblingRect.top < imgRect.bottom && siblingRect.bottom > imgRect.top
       ? {left: imgRect.left, right: imgRect.right, top: siblingRect.top, bottom: siblingRect.bottom} : imgRect
   }
 


### PR DESCRIPTION
If WidgetBufferView has "display: none" style, its getBoundingClientRect() returns {0,0,0,0,0...} so it's useless.
I'm not sure at all that this PR works but I wish this will help https://github.com/hedgedoc/react-client/issues/2446
Thanks