### PR TITLE
announceDOM: position fixed instead of absolute

### DIFF
--- a/src/editorview.ts
+++ b/src/editorview.ts
@@ -174,7 +174,7 @@ export class EditorView {
     this.scrollDOM.appendChild(this.contentDOM)
 
     this.announceDOM = document.createElement("div")
-    this.announceDOM.style.cssText = "position: absolute; top: -10000px"
+    this.announceDOM.style.cssText = "position: fixed; top: -10000px"
     this.announceDOM.setAttribute("aria-live", "polite")
 
     this.dom = document.createElement("div")


### PR DESCRIPTION
This text is there for screen readers only, but it shows up if there is enough vertical space above the CM, like in this screenshot (there are more CMs below the viewport):


<img width="1085" alt="Scherm­afbeelding 2022-11-27 om 14 55 48" src="https://user-images.githubusercontent.com/6933510/204139017-43a6d905-d2e0-4f7b-8bdb-62a448222c94.png">
