### PR TITLE
Add paste support for uri-text

### DIFF
--- a/src/input.ts
+++ b/src/input.ts
@@ -628,7 +628,7 @@ handlers.paste = (view: EditorView, event: ClipboardEvent) => {
   view.observer.flush()
   let data = brokenClipboardAPI ? null : event.clipboardData
   if (data) {
-    doPaste(view, data.getData("text/plain"))
+    doPaste(view, data.getData("text/plain") || data.getData("text/uri-text"))
     event.preventDefault()
   } else {
     capturePaste(view)


### PR DESCRIPTION
## Issue
On iOS, when copying a website (on anything else) using the iOS share sheet, it formats it as a `text/uri-text` rather than `text/plain`. When attempting to paste this in the Codemirror editor, `data.getData("text/plain")` returns an empty string, and to the end user nothing happens. This issue has been reported by users of ours at Supernotes and other apps using the Codemirror editor. 

## Reproduction
The simplest way to re-produce this is to try pasting a link originally copied with the iOS Share Sheet into the [demo editor on the Codemirror homepage](https://codemirror.net/) – nothing will be pasted.

## Fix
By adding `data.getData("text/uri-text")` after a logical OR, this fixes the issue and the text string is returned as expected.