### PR TITLE
Click within a non-zero-length multi-selection to remove

### DIFF
--- a/src/input.ts
+++ b/src/input.ts
@@ -567,7 +567,7 @@ function basicMouseSelection(view: EditorView, event: MouseEvent) {
       }
       if (extend)
         return startSel.replaceRange(startSel.main.extend(range.from, range.to))
-      else if (multiple && startSel.ranges.length > 1 && startSel.ranges.some(r => r.eq(range)))
+      else if (multiple && startSel.ranges.length > 1 && startSel.ranges.some(r => r.from <= range.from && range.to <= r.to))
         return removeRange(startSel, range)
       else if (multiple)
         return startSel.addRange(range)
@@ -579,7 +579,7 @@ function basicMouseSelection(view: EditorView, event: MouseEvent) {
 
 function removeRange(sel: EditorSelection, range: SelectionRange) {
   for (let i = 0;; i++) {
-    if (sel.ranges[i].eq(range))
+    if (sel.ranges[i].from <= range.from && range.to <= sel.ranges[i].to)
       return EditorSelection.create(sel.ranges.slice(0, i).concat(sel.ranges.slice(i + 1)),
                                     sel.mainIndex == i ? 0 : sel.mainIndex - (sel.mainIndex > i ? 1 : 0))
   }


### PR DESCRIPTION
## Why

Currently if you have multiple selections in an editor, `Cmd`+`Clicking` a 0-length selection will remove it, but `Cmd`+`Clicking` a >0-length selection will not:

https://user-images.githubusercontent.com/16962017/228073871-504c1ef4-086e-4352-97c5-cd3642a3adac.mov



This is because the `.eq` method compares both `head` and `anchor`. When you have a non-zero-length selection those values will not be the same, but the click range will be the same, so `.eq` will never return `true`.

Instead, we should check if the click range is anywhere within a selection range when deciding it remove it. 


## Test Plan


Now, both 0-length and >0-length selections can be added and removed:

https://user-images.githubusercontent.com/16962017/228073684-e73fb26a-5406-4aca-a59f-4d196e29be97.mov