### PR TITLE
Fix potential divison by zero when calculating heightMetrics

### DIFF
--- a/src/heightmap.ts
+++ b/src/heightmap.ts
@@ -291,7 +291,8 @@ class HeightMapGap extends HeightMap {
     if (oracle.lineWrapping) {
       let totalPerLine = Math.min(this.height, oracle.lineHeight * lines)
       perLine = totalPerLine / lines
-      perChar = (this.height - totalPerLine) / (this.length - lines - 1)
+      if (this.height !== totalPerLine)
+        perChar = (this.height - totalPerLine) / (this.length - lines - 1)
     } else {
       perLine = this.height / lines
     }


### PR DESCRIPTION
FIX: Fixes an issue where the Gutter Element breaks due to a divsion by zero (https://github.com/codemirror/dev/issues/1132)

`this.height` seems to always have the same value as `this.height` whenever a line does not wrap. This prevents the division by zero by setting the value of `perChar` to `0`, which is always the value whenever the line does not wrap.