### PR TITLE
Handle null from coordsAtPos

### DIFF
--- a/src/layer.ts
+++ b/src/layer.ts
@@ -149,8 +149,9 @@ function rectanglesForRange(view: EditorView, className: string, range: Selectio
       // coordinates on the proper side of block widgets, since
       // normalizing the side there, though appropriate for most
       // coordsAtPos queries, would break selection drawing.
-      let fromCoords = view.coordsAtPos(from, (from == line.to ? -2 : 2) as any)!
-      let toCoords = view.coordsAtPos(to, (to == line.from ? 2 : -2) as any)!
+      let fromCoords = view.coordsAtPos(from, (from == line.to ? -2 : 2) as any)
+      let toCoords = view.coordsAtPos(to, (to == line.from ? 2 : -2) as any)
+      if (!fromCoords || !toCoords) return;
       top = Math.min(fromCoords.top, toCoords.top, top)
       bottom = Math.max(fromCoords.bottom, toCoords.bottom, bottom)
       if (dir == Direction.LTR)


### PR DESCRIPTION
At Replit we've been seeing a number of errors come in with the following message:

```
TypeError
Cannot read properties of null (reading 'top')
```
with the stack trace: 
```
  at addSpan(./node_modules/.pnpm/@codemirror+view@6.9.4/node_modules/@codemirror/view/dist/index.js:7652:39)
  at drawForLine(./node_modules/.pnpm/@codemirror+view@6.9.4/node_modules/@codemirror/view/dist/index.js:7670:29)
  at rectanglesForRange(./node_modules/.pnpm/@codemirror+view@6.9.4/node_modules/@codemirror/view/dist/index.js:7624:33)
  at RectangleMarker.forRange(./node_modules/.pnpm/@codemirror+view@6.9.4/node_modules/@codemirror/view/dist/index.js:7577:20)
  at <anonymous>(./node_modules/.pnpm/@codemirror+view@6.9.4/node_modules/@codemirror/view/dist/index.js:7837:84)
  at Array.map(<anonymous>)
  at selectionLayer.markers(./node_modules/.pnpm/@codemirror+view@6.9.4/node_modules/@codemirror/view/dist/index.js:7837:44)
  at LayerView.measure(./node_modules/.pnpm/@codemirror+view@6.9.4/node_modules/@codemirror/view/dist/index.js:7720:27)
  at measured(./node_modules/.pnpm/@codemirror+view@6.9.4/node_modules/@codemirror/view/dist/index.js:6684:34)
  at Array.map(<anonymous>)
  at EditorView.measure(./node_modules/.pnpm/@codemirror+view@6.9.4/node_modules/@codemirror/view/dist/index.js:6682:42)
  at this.measureScheduled(./node_modules/.pnpm/@codemirror+view@6.9.4/node_modules/@codemirror/view/dist/index.js:6811:79)
  at sentryWrapped(./node_modules/.pnpm/@sentry+browser@7.42.0/node_modules/@sentry/browser/esm/helpers.js:90:17)
```


I don't have a good reproduction of what causes the error, but based on the stack trace it seems we're trying to access `.top` from an object that is null in`addSpan`. I can only assume that is due to the non-null casts hiding potentially null values `fromCoords` and `toCoords`.

Without knowing the root cause of the bug, it seems the next best solution is to handle situations when these values would be null safely.