### PR TITLE
No negative padding in scrollPastEnd

### DIFF
--- a/src/scrollpastend.ts
+++ b/src/scrollpastend.ts
@@ -8,7 +8,7 @@ const plugin = ViewPlugin.fromClass(class {
   update(update: ViewUpdate) {
     let {view} = update
     let height = view.viewState.editorHeight - view.defaultLineHeight - view.documentPadding.top - 0.5
-    if (height != this.height) {
+    if (height >= 0 && height != this.height) {
       this.height = height
       this.attrs = {style: `padding-bottom: ${height}px`}
     }


### PR DESCRIPTION
Before setting a new `scrollPastEnd` height, ensure the value is not negative to prevent issues where the scroll position is off on a just initialized editor.

Negative values come up particularly if `view.viewState.editorHeight` is not yet available.

Example of the problem when a negative padding gets set then updated. Scroll position is not the top where it should be (based on the cursor at initialization). Having a document that's not longer than the height of the editor is key.

<img width="452" alt="Screenshot 2023-06-07 at 11 07 13 AM" src="https://github.com/codemirror/view/assets/777155/897e2dca-ed64-47ee-a81f-0dae6a4f6c14">
