### PR TITLE
Use `insertLineBreak` instead of `insertParagraph` for PendingKey Enter

### DIFF
--- a/src/input.ts
+++ b/src/input.ts
@@ -233,7 +233,7 @@ export class InputState {
 
 const PendingKeys = [
   {key: "Backspace", keyCode: 8, inputType: "deleteContentBackward"},
-  {key: "Enter", keyCode: 13, inputType: "insertParagraph"},
+  {key: "Enter", keyCode: 13, inputType: "insertLineBreak"},
   {key: "Delete", keyCode: 46, inputType: "deleteContentForward"}
 ]
 


### PR DESCRIPTION
To handle https://github.com/codemirror/dev/issues/1145
Based on the suggestion here: https://github.com/codemirror/dev/issues/1145#issuecomment-1617709896

Tested here:
* Visit https://cm-view-ada1204-debug.bradyatreplit.repl.co on browserstack.com, using a Google Pixel 7 on Chrome
* Click after the `t` in "Print" in the codemirror editor
* Press `Backspace`
* Press `t`
* Press `Enter`
* Notice we move only one newline down instead of 2, as it previously did