### PR TITLE
Fix exception thrown when offsetWidth/offsetHeight is 0

### DIFF
--- a/src/viewstate.ts
+++ b/src/viewstate.ts
@@ -257,8 +257,8 @@ export class ViewState {
     if (domRect.width && domRect.height) {
       let scaleX = domRect.width / dom.offsetWidth
       let scaleY = domRect.height / dom.offsetHeight
-      if (scaleX > 0.995 && scaleX < 1.005) scaleX = 1
-      if (scaleY > 0.995 && scaleY < 1.005) scaleY = 1
+      if (scaleX > 0.995 && scaleX < 1.005 || !isFinite(scaleX)) scaleX = 1
+      if (scaleY > 0.995 && scaleY < 1.005 || !isFinite(scaleY)) scaleY = 1
       if (this.scaleX != scaleX || this.scaleY != scaleY) {
         this.scaleX = scaleX; this.scaleY = scaleY
         result |= UpdateFlag.Geometry


### PR DESCRIPTION
In unit tests, I get an exception because dom.offsetHeight is 0, scaleY turns to infinity and some calculated values become NaN. This PR sets scaleX and scaleY to 1 if it would otherwise be inifitity.

I think this should be fixed since other people running unit tests would hit this issue and it's not trivial to figure out why the problem exists.