### PR TITLE
Fix double caret blink in Sonoma

### DIFF
--- a/src/draw-selection.ts
+++ b/src/draw-selection.ts
@@ -114,9 +114,5 @@ const themeSpec = {
     "&::selection": {backgroundColor: "transparent !important"}
   }
 }
-if (CanHidePrimary) {
-  let anySpec = (themeSpec as any)
-  anySpec[".cm-content"].caretColor = "transparent !important"
-  anySpec[".cm-line"].caretColor = "transparent !important"
-}
+if (CanHidePrimary) (themeSpec as any)[".cm-content"].caretColor = "transparent !important"
 const hideNativeSelection = Prec.highest(EditorView.theme(themeSpec))

--- a/src/draw-selection.ts
+++ b/src/draw-selection.ts
@@ -114,5 +114,9 @@ const themeSpec = {
     "&::selection": {backgroundColor: "transparent !important"}
   }
 }
-if (CanHidePrimary) (themeSpec as any)[".cm-content"].caretColor = "transparent !important"
+if (CanHidePrimary) {
+  let anySpec = (themeSpec as any)
+  anySpec[".cm-content"].caretColor = "transparent !important"
+  anySpec[".cm-line"].caretColor = "transparent !important"
+}
 const hideNativeSelection = Prec.highest(EditorView.theme(themeSpec))

--- a/src/draw-selection.ts
+++ b/src/draw-selection.ts
@@ -114,5 +114,9 @@ const themeSpec = {
     "&::selection": {backgroundColor: "transparent !important"}
   }
 }
-if (CanHidePrimary) (themeSpec as any)[".cm-line"].caretColor = "transparent !important"
+if (CanHidePrimary) {
+  let anySpec = (themeSpec as any)
+  anySpec[".cm-content"].caretColor = "transparent !important"
+  anySpec[".cm-line"].caretColor = "transparent !important"
+}
 const hideNativeSelection = Prec.highest(EditorView.theme(themeSpec))


### PR DESCRIPTION
This issue only reproduces in macOS Sonoma (reproducible with https://codemirror.net/try/ too). Please check out the video.

https://github.com/codemirror/view/assets/6745066/81113540-9941-460d-afe3-7cafe2703d8b

It seems by setting caretColor to cm-line doesn't hide the native caret, I fixed it in my project by adding:

```css
.cm-content {
  caret-color: transparent !important;
}

// or through the theming system
```

Feel free to close and make your fix as I don't know what's the best practice. I am just sharing an example. Thanks.