### PR TITLE
Use a span instead of image to prevent word-breaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codemirror/view",
-  "version": "6.22.0",
+  "version": "6.23.0",
   "description": "DOM view component for the CodeMirror code editor",
   "scripts": {
     "test": "cm-runtests",

--- a/src/inlineview.ts
+++ b/src/inlineview.ts
@@ -273,9 +273,10 @@ export class WidgetBufferView extends ContentView {
 
   sync() {
     if (!this.dom) {
-      let dom = document.createElement("img")
-      dom.className = "cm-widgetBuffer"
-      dom.setAttribute("aria-hidden", "true")
+      let dom = document.createElement("span");
+      dom.className = "cm-widgetBuffer";
+      dom.setAttribute("aria-hidden", "true");
+      dom.style.whiteSpace = "nowrap";
       this.setDOM(dom)
     }
   }


### PR DESCRIPTION
Fixes https://github.com/codemirror/dev/issues/989

Currently the `<img>` tag used for the `cm-WidgetBuffer` causes a word break. This is especially noticeable with collaborative cursors (i.e., from YJS and y-codemirror.next). The breaking behavior is weird. Joining with a `&NoBreak;` in the text causes content changes in the contenteditable so this doesn't work reliably:

```js
      let dom = document.createElement("img");
      dom.insertAdjacentText("beforebegin", "\u2060");
      dom.insertAdjacentText("afterend", "\u2060");
      dom.className = "cm-widgetBuffer";
      dom.setAttribute("aria-hidden", "true");
```      

This comment from @marijnh was insightful:

https://github.com/codemirror/dev/issues/989#issuecomment-1312503295

It turns out there is such a mysterious element: `<nobr>`. It was never in a spec but was implemented. But it has been deprecated. Changing the buffer it a `<nobr>` worked in Safari and Firefox (even with obscure CSS problems and no CSS) but didn't work in all cases with Chrome (3D transforms seemed to still break, which might not be important).

The attached fix just uses a `<span style="white-space:nowrap">` and it works in all of the cases we want. 

In my application CSS I also have (not sure if it is required):

```css
.ͼ1 .cm-widgetBuffer {
  display: inline;
}

.ͼ1 .cm-widgetBuffer::before, .ͼ1 .cm-widgetBuffer::after {
  content: '\002060' !important; // this is a unicode non-breaking space / empty word-joiner char
  display: inline;
  white-space: nowrap;
}
```