### PR TITLE
Android/GBoard: Fix pressing Enter after accepting a completion doesn't fire event handlers (#1312)

### DIFF
--- a/src/domchange.ts
+++ b/src/domchange.ts
@@ -127,6 +127,11 @@ export function applyDOMChange(view: EditorView, domChange: DOMChange): boolean 
         ((change.from == sel.from && change.to == sel.to &&
           change.insert.length == 1 && change.insert.lines == 2 &&
           dispatchKey(view.contentDOM, "Enter", 13)) ||
+         // Emitted by GBoard when pressing enter just after accepting
+         // a keyboard autosuggestion (#1312):
+         (change.from == sel.from - 1 && change.to == sel.to &&
+          change.insert.length == 1 && change.insert.lines == 2 &&
+          dispatchKey(view.contentDOM, "Enter", 13)) ||
          ((change.from == sel.from - 1 && change.to == sel.to && change.insert.length == 0 ||
            lastKey == 8 && change.insert.length < change.to - change.from && change.to > sel.head) &&
           dispatchKey(view.contentDOM, "Backspace", 8)) ||

--- a/src/domchange.ts
+++ b/src/domchange.ts
@@ -127,8 +127,9 @@ export function applyDOMChange(view: EditorView, domChange: DOMChange): boolean 
         ((change.from == sel.from && change.to == sel.to &&
           change.insert.length == 1 && change.insert.lines == 2 &&
           dispatchKey(view.contentDOM, "Enter", 13)) ||
-         // Emitted by GBoard when pressing enter just after accepting
-         // a keyboard autosuggestion (#1312):
+         // This case handles events emitted by GBoard when the user
+         // presses enter just after accepting a keyboard
+         // autosuggestion (#1312):
          (change.from == sel.from - 1 && change.to == sel.to &&
           change.insert.length == 1 && change.insert.lines == 2 &&
           dispatchKey(view.contentDOM, "Enter", 13)) ||


### PR DESCRIPTION
# Summary

Fixes https://github.com/codemirror/dev/issues/1312, by extending the <kbd>enter</kbd> event emitting logic for Android keyboards.

# Notes

If I
1. log `change` and `sel` just before the added condition to the `if` statement and
2. accept a GBoard suggestion and press <kbd>enter</kbd>,

then at the location of the change, we have
```js
change: {
    from: 13,
    to: 14,
    insert: { length: 1, text: ['', ''] }
}
```
and
```js
sel: {
    from: 14,
    to: 14,
    flags: 1073741767,
    anchor: 14,
    assoc: 0,
    bidiLevel: null,
    empty: true,
    goalColumn: undefined,
    head: 14
}
```