### PR TITLE
Account for scale when updating the gutter height

### DIFF
--- a/src/gutter.ts
+++ b/src/gutter.ts
@@ -146,7 +146,9 @@ const gutterView = ViewPlugin.fromClass(class {
       let vpOverlap = Math.min(vpA.to, vpB.to) - Math.max(vpA.from, vpB.from)
       this.syncGutters(vpOverlap < (vpB.to - vpB.from) * 0.8)
     }
-    if (update.geometryChanged) this.dom.style.minHeight = this.view.contentHeight + "px"
+    if (update.geometryChanged) {
+      this.dom.style.minHeight = (this.view.contentHeight / this.view.scaleY) + "px"
+    }
     if (this.view.state.facet(unfixGutters) != !this.fixed) {
       this.fixed = !this.fixed
       this.dom.style.position = this.fixed ? "sticky" : ""


### PR DESCRIPTION
The gutter ends up at an incorrect height when the editor is scaled after it is created. 

<img width="307" alt="codemirror-gutter-issue" src="https://github.com/codemirror/view/assets/1153033/ab7b8e02-6224-4b5f-8537-d16674e2b366">

The issue seems to be that `scaleY` is used when calculating the gutter height in the constructor but not in subsequent view updates.