### PR TITLE
Replace navigator with nav in browser.ts

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -25,6 +25,6 @@ export default {
   android: /Android\b/.test(nav.userAgent),
   webkit,
   safari,
-  webkit_version: webkit ? +(/\bAppleWebKit\/(\d+)/.exec(navigator.userAgent) || [0, 0])[1] : 0,
+  webkit_version: webkit ? +(/\bAppleWebKit\/(\d+)/.exec(nav.userAgent) || [0, 0])[1] : 0,
   tabSize: doc.documentElement.style.tabSize != null ? "tab-size" : "-moz-tab-size"
 }


### PR DESCRIPTION
Fixed inconsistent use of nav, which results in an error when navigator is not defined (ex. server side rendering)