### PR TITLE
Fix tooltip overflow

### DIFF
--- a/src/tooltip.ts
+++ b/src/tooltip.ts
@@ -314,9 +314,11 @@ const tooltipPlugin = ViewPlugin.fromClass(class {
       let arrowHeight = arrow ? Arrow.Size : 0
       let width = size.right - size.left, height = knownHeight.get(tView) ?? size.bottom - size.top
       let offset = tView.offset || noOffset, ltr = this.view.textDirection == Direction.LTR
-      let left = size.width > space.right - space.left ? (ltr ? space.left : space.right - size.width)
-        : ltr ? Math.min(pos.left - (arrow ? Arrow.Offset : 0) + offset.x, space.right - width)
-        : Math.max(space.left, pos.left - width + (arrow ? Arrow.Offset : 0) - offset.x)
+      let left = size.width > space.right - space.left
+        ? (ltr ? space.left : space.right - size.width)
+        : ltr
+          ? Math.max(space.left, Math.min(pos.left - (arrow ? Arrow.Offset : 0) + offset.x, space.right - width))
+          : Math.min(Math.max(space.left, pos.left - width + (arrow ? Arrow.Offset : 0) - offset.x), space.right - width)
       let above = this.above[i]
       if (!tooltip.strictSide && (above
             ? pos.top - (size.bottom - size.top) - offset.y < space.top


### PR DESCRIPTION
When a tooltip doesn't fit inside the given space, it should move a bit to not overflow.

This worked fine for just one side --- the code assumes that the user doesn't pass a starting position outside the available space. This was fixed.