### PR TITLE
#1430 Avoid exceptions when running in the headless browser mode

### DIFF
--- a/src/domobserver.ts
+++ b/src/domobserver.ts
@@ -430,7 +430,7 @@ export class DOMObserver {
     win.addEventListener("resize", this.onResize)
     if (this.printQuery) { 
       if (this.printQuery.addEventListener) this.printQuery.addEventListener("change", this.onPrint)
-      else this.printQuery.addListener(this.onPrint)
+      else if (this.printQuery.addListener) this.printQuery.addListener(this.onPrint)
     }
     else win.addEventListener("beforeprint", this.onPrint)
     win.addEventListener("scroll", this.onScroll)
@@ -442,7 +442,7 @@ export class DOMObserver {
     win.removeEventListener("resize", this.onResize)
     if (this.printQuery) {
       if (this.printQuery.removeEventListener) this.printQuery.removeEventListener("change", this.onPrint)
-      else this.printQuery.removeListener(this.onPrint)
+      else if (this.printQuery.removeListener) this.printQuery.removeListener(this.onPrint)
     }
     else win.removeEventListener("beforeprint", this.onPrint)
     win.document.removeEventListener("selectionchange", this.onSelectionChange)

--- a/src/editorview.ts
+++ b/src/editorview.ts
@@ -408,14 +408,14 @@ export class EditorView {
   measure(flush = true) {
     if (this.destroyed) return
     if (this.measureScheduled > -1) this.win.cancelAnimationFrame(this.measureScheduled)
-    if (this.observer.delayedAndroidKey) {
+    if (this.observer && this.observer.delayedAndroidKey) {
       this.measureScheduled = -1
       this.requestMeasure()
       return
     }
     this.measureScheduled = 0 // Prevent requestMeasure calls from scheduling another animation frame
 
-    if (flush) this.observer.forceFlush()
+    if (this.observer && flush) this.observer.forceFlush()
 
     let updated: ViewUpdate | null = null
     let sDOM = this.scrollDOM, scrollTop = sDOM.scrollTop * this.scaleY


### PR DESCRIPTION
Hi @marijnh,

I've added some checks for undefined values to prevent exceptions occuring when partial browser functionality used during headless Chrome runs. 

These checks don't change any of the existing logic. My test running smoothly with these fixes.
I would greatly appreciate it if these changes could be released asap.

Thank you!

https://github.com/codemirror/dev/issues/1430
