### PR TITLE
Pass prevWidget to widget.updateDOM

### DIFF
--- a/src/blockview.ts
+++ b/src/blockview.ts
@@ -204,7 +204,7 @@ export class BlockWidgetView extends ContentView implements BlockView {
   get children() { return noChildren }
 
   sync(view: EditorView) {
-    if (!this.dom || !this.widget.updateDOM(this.dom, view)) {
+    if (!this.dom || !this.widget.updateDOM(this.dom, view, this.prevWidget)) {
       if (this.dom && this.prevWidget) this.prevWidget.destroy(this.dom)
       this.prevWidget = null
       this.setDOM(this.widget.toDOM(view))

--- a/src/decoration.ts
+++ b/src/decoration.ts
@@ -121,7 +121,7 @@ export abstract class WidgetType {
   /// true to indicate that it could update, false to indicate it
   /// couldn't (in which case the widget will be redrawn). The default
   /// implementation just returns false.
-  updateDOM(dom: HTMLElement, view: EditorView): boolean { return false }
+  updateDOM(dom: HTMLElement, view: EditorView, prevWidget: WidgetType | null): boolean { return false }
 
   /// @internal
   compare(other: WidgetType): boolean {

--- a/src/inlineview.ts
+++ b/src/inlineview.ts
@@ -178,7 +178,7 @@ export class WidgetView extends ContentView {
   }
 
   sync(view: EditorView) {
-    if (!this.dom || !this.widget.updateDOM(this.dom, view)) {
+    if (!this.dom || !this.widget.updateDOM(this.dom, view, this.prevWidget)) {
       if (this.dom && this.prevWidget) this.prevWidget.destroy(this.dom)
       this.prevWidget = null
       this.setDOM(this.widget.toDOM(view))


### PR DESCRIPTION
In some scenarios, I would like to remove the previous event listener in `widget.updateDOM`, but missing the reference to previous listener in `widget.updateDOM`.

For exaxmple:

```ts
interface WidgetOptions {
  text: string;
  onClick: () => void;
}

class MyWidget extends WidgetType {
  constructor( private options: WidgetOptions ) {
    super()
  }

  toDOM() {
    const dom = document.createElement('span')

    dom.textContent = this.options.text
    dom.addEventListener('click', this.handleClick, false)

    return dom
  }

  handleClick() {
    this.options.onClick()
  }

  updateDOM(dom) {
    dom.textContent = this.options.text

    // Cannot remove previous listener, as we missing the reference to prevWidget.handleClick here
    dom.removeEventListener('click', ???, false)

    dom.addEventListener('click', this.handleClick, false)
    return true
  }

  ...
}
```

This PR pass `prevWidget` to `widget.updateDOM` to solve this.