### PR TITLE
fix: Update `w3c-keyname` to v2.2.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@codemirror/state": "^6.5.0",
     "style-mod": "^4.1.0",
-    "w3c-keyname": "^2.2.4"
+    "w3c-keyname": "^2.2.8"
   },
   "devDependencies": {
     "@codemirror/buildhelper": "^1.0.0"


### PR DESCRIPTION
This PR ensures that package managers will install the most recent version of `w3c-keyname`.

I realized that my `yarn` had installed an older version of `w3c-keyname` on my side (2.2.6 instead of the most recent version 2.2.8). Something changed in between the two version that impacts macOS. Specifically, the older version's `keyname` reported, as key name, for the shortcut `Cmd-Alt-∆` on macOS a `j` character, whereas 2.2.8 correctly reports `∆`.

I noticed that because I am currently working on a shortcut capturer to let users define custom keyboard shortcuts, and I noticed that my implementation (which also relies on `keyName` to be consistent between my code and CodeMirror) outputted different key names from what CodeMirror saw.

This may be even more detrimental, though, since before I installed `w3c-keyname`, no other package depended on it, meaning that other users probably also have 2.2.6 installed. This might lead to false positives, and I remember that it is extremely difficult to find even hard-coded editor shortcuts for macOS that work consistently.

***

My current mitigation is to put a resolution in my package json to enforce version 2.2.8.

***

A specific bug that this PR fixes for everyone that has 2.2.6 installed:

Imagine you have the keyboard shortcut `Cmd-Alt-J` that you wish to use on macOS. You could do it like so:

```ts
// ...
{ mac: 'Cmd-Alt-J', run: command }
// ...
```

However, that will never trigger when using `w3c-keyname` version 2.2.6, because the keyboard event reports the character `∆` instead of `j`. But, using the other version won't work either with version 2.2.6:

```ts
// ...
{ mac: 'Cmd-Alt-∆', run: command }
// ...
```

When using `w3c-keyname` version 2.2.8, however, the keyboard shortcut `Cmd-Alt-∆` will properly trigger, as expected.