### PR TITLE
Add crelt as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "license": "MIT",
   "dependencies": {
     "@codemirror/state": "^6.5.0",
+    "crelt": "^1.0.6",
     "style-mod": "^4.1.0",
     "w3c-keyname": "^2.2.4"
   },


### PR DESCRIPTION
The "showDialog" feature released in 6.37.0 added a dependency on "crelt"(https://github.com/codemirror/view/blob/main/src/dialog.ts#L3) but this was not added to the package.json. 