### PR TITLE
Guard against Infinity height in HeightMap which results in NaN to value and offset

### DIFF
--- a/src/viewstate.ts
+++ b/src/viewstate.ts
@@ -49,7 +49,7 @@ function fullPixelRange(dom: HTMLElement, paddingTop: number): Rect {
           top: paddingTop, bottom: rect.bottom - (rect.top + paddingTop)}
 }
 
-const enum VP {
+export const enum VP {
   // FIXME look into appropriate value of this through benchmarking etc
   Margin = 1000,
   // coveredBy requires at least this many extra pixels to be covered


### PR DESCRIPTION
I was previously on codemirror/view 6.17.1 (Aug 31, 2023) and upgraded to codemirror/view 6.36.3 (Feb 17, 2025). 
Likewise upgraded from codemirror/state 6.4.1 (Feb 19, 2024) to codemirror/state 6.5.2 (Feb 3, 2025). 

Between those versions were some changes to improve height calculations with regards to the HeightOracle and viewports. Something there introduced an issue where when splitting panes containing the Codemirror 6 editor, the new pane would briefly have a HeightMap height of Infinity which would result in downstream calculations of the offset and value parameters turning into NaN. 

This would happen when enabling linewrapping, since linewrapping allows each line height to be variable. The end result was  that only partial lines were visible in the editor, or the editor was unscrollable and stuck at the bottom of the document. 

Unfortunately I don't have a minimal reproduction of this, but these were the code changes I made in a local patch to codemirror to prevent the display breakage in our application. 

I am interested in helping make changes to the original repository. Please tell me what I can do to assist.
