### PR TITLE
WIP: introduce unscaled measurements for consistent gaps in a scaled editor

### DIFF
--- a/src/blockview.ts
+++ b/src/blockview.ts
@@ -120,7 +120,14 @@ export class LineView extends ContentView implements BlockView {
     }
   }
 
-  measureTextSize(): {lineHeight: number, charWidth: number, textHeight: number} | null {
+  measureTextSize(): {
+    lineHeight: number,
+    charWidth: number,
+    textHeight: number,
+    originalLineHeight: number,
+    originalCharWidth: number,
+    originalTextHeight: number
+  } | null {
     if (this.children.length == 0 || this.length > 20) return null
     let totalWidth = 0, textHeight!: number
     for (let child of this.children) {
@@ -130,11 +137,22 @@ export class LineView extends ContentView implements BlockView {
       totalWidth += rects[0].width
       textHeight = rects[0].height
     }
-    return !totalWidth ? null : {
-      lineHeight: this.dom!.getBoundingClientRect().height,
+
+    if (!totalWidth) return null
+
+    const lineHeight = this.dom!.getBoundingClientRect().height
+    const originalLineHeight = this.dom!.clientHeight
+    const scale = originalLineHeight / lineHeight
+
+    const result = {
+      lineHeight: lineHeight,
       charWidth: totalWidth / this.length,
-      textHeight
+      textHeight,
+      originalLineHeight: originalLineHeight,
+      originalCharWidth: (totalWidth / this.length) * scale,
+      originalTextHeight: textHeight * scale
     }
+    return result
   }
 
   coordsAt(pos: number, side: number): Rect | null {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,6 +17,8 @@ export type Command = (target: EditorView) => boolean
 
 export const clickAddsSelectionRange = Facet.define<(event: MouseEvent) => boolean>()
 
+export const disableAutoScrollToAnchor = Facet.define<boolean>()
+
 export const dragMovesSelection = Facet.define<(event: MouseEvent) => boolean>()
 
 export const mouseSelectionStyle = Facet.define<MakeSelectionStyle>()

--- a/src/heightmap.ts
+++ b/src/heightmap.ts
@@ -20,7 +20,6 @@ export class HeightOracle {
   originalLineHeight: number = 14 // The original height of an entire line (line-height)
   originalCharWidth: number = 7
   originalTextHeight: number = 14 // The original height of the actual font (font-size)
-  originalLineLength: number = 30
 
   constructor(public lineWrapping: boolean) {}
 
@@ -76,7 +75,6 @@ export class HeightOracle {
     this.originalLineHeight = originalLineHeight
     this.originalCharWidth = originalCharWidth
     this.originalTextHeight = originalTextHeight
-    this.originalLineLength = originalLineLength
     if (changed) {
       this.heightSamples = {}
       this.originalHeightSamples = {}


### PR DESCRIPTION
This PR hopes to resolve the issue mentioned in [this discussion](https://discuss.codemirror.net/t/synchronization-issue-between-codemirror-viewport-and-a-canvas-viewport/9318), where the editorview gaps are inconsistent as the editor is being scaled (only noticeable if scrolled down far enough).
I found that the problem was in the implementation of the `DocView.computeBlockGapDeco` where the "screen"-space coordinates divided by the scaleY [were used to calculate the height of the gap](https://github.com/codemirror/view/blob/014076ae6e47ab04e6cf990d0561f4c4b6b53949/src/docview.ts#L502C9-L502C95).
To solve this issue, I introduced originalLineHeight, originalCharWidth, originalTop, originalHeight, etc. in the HeightOracle and HeightMaps, which are the unscaled sizes and coordinates of the lines (instead of the screen coordinates). These are then used to calculate the height of the gaps. This approach avoids floating-point errors that could occur when adding up the heights of the lines (which was causing the visual bug before), as it now sums the unscaled heights of each line instead.

- [This is how scaling the editor looked before the change](https://imgur.com/a/3STKwcu)
- [And here is how it looks after the change](https://imgur.com/a/AqHEUdo)

There might be some bugs as this is still a work in progress.